### PR TITLE
SREFTP-4608 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.tfstate.backup
 .terraform
 .terraform.lock.hcl
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ This module is forked from [tf_aws_elasticache_redis Communitiy module](https://
 
 ## Terraform versions
 
-Terraform 0.12. Pin module version to `~> v2.0`. Submit pull-requests to `master` branch.
+Terraform 1.3 used in master branch.
+Check version tags for older versions.
 
-Terraform 0.11. Pin module version to `~> v1.0`. Submit pull-requests to `terraform011` branch.
+
 
 ## Usage
 
 ```hcl
 module "redis" {
-  source  = "github.com/flywirecorp/tf_aws_elasticache_redis.git?ref=v2.2.0"
+  source  = "github.com/flywirecorp/tf_aws_elasticache_redis.git?ref=v2.3.0"
 
   env            = "dev"
   name           = "thtest"
@@ -44,15 +45,15 @@ module "redis" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.12 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.12 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
 
 ## Modules
@@ -117,9 +118,6 @@ No modules.
 | <a name="output_port"></a> [port](#output\_port) | Redis port (default is 6379) |
 | <a name="output_redis_security_group_id"></a> [redis\_security\_group\_id](#output\_redis\_security\_group\_id) | ID of the managed Security Group generated for Redis |
 | <a name="output_redis_subnet_group_name"></a> [redis\_subnet\_group\_name](#output\_redis\_subnet\_group\_name) | Name of the Redis subnet |
-
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Authors
 
 Created by [Tim Hartmann](https://github.com/tfhartmann). Maintained by [Anton Babenko](https://github.com/antonbabenko) and [these awesome contributors](https://github.com/terraform-community-modules/tf_aws_elasticache_redis/graphs/contributors).

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ No modules.
 | <a name="output_port"></a> [port](#output\_port) | Redis port (default is 6379) |
 | <a name="output_redis_security_group_id"></a> [redis\_security\_group\_id](#output\_redis\_security\_group\_id) | ID of the managed Security Group generated for Redis |
 | <a name="output_redis_subnet_group_name"></a> [redis\_subnet\_group\_name](#output\_redis\_subnet\_group\_name) | Name of the Redis subnet |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
 ## Authors
 
 Created by [Tim Hartmann](https://github.com/tfhartmann). Maintained by [Anton Babenko](https://github.com/antonbabenko) and [these awesome contributors](https://github.com/terraform-community-modules/tf_aws_elasticache_redis/graphs/contributors).

--- a/README.md
+++ b/README.md
@@ -12,13 +12,11 @@ This module is forked from [tf_aws_elasticache_redis Communitiy module](https://
 Terraform 1.3 used in master branch.
 Check version tags for older versions.
 
-
-
 ## Usage
 
 ```hcl
 module "redis" {
-  source  = "github.com/flywirecorp/tf_aws_elasticache_redis.git?ref=v2.3.0"
+  source  = "github.com/flywirecorp/tf_aws_elasticache_redis.git?ref=v2.3.1"
 
   env            = "dev"
   name           = "thtest"
@@ -47,14 +45,14 @@ module "redis" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.12"
+      version = "~> 5"
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.3"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -7,7 +7,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "~> 3.5"
     }
   }
 }


### PR DESCRIPTION
Terraform/providers/upstream upgrades for terraform_module_redis
Bump Terraform version to 1.3, AWS provider version to 5, Random provider to 3.5